### PR TITLE
ページ全体の設定を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,3 +2,28 @@
  *= require_tree .
  *= require_self
  */
+
+ /* 全体 */
+
+.base-container {
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+/* max-width */
+
+.mw-sm {
+  max-width: 576px;
+}
+
+.mw-md {
+  max-width: 768px;
+}
+
+.mw-lg {
+  max-width: 992px;
+}
+
+.mw-xl {
+  max-width: 1200px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  def max_width
+    if controller_name == "texts" && action_name == "show"
+      "mw-md"
+      # Devise 導入後にコメントアウトを解除
+      # elsif devise_controller?
+      #  "mw-sm"
+    else
+      "mw-xl"
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,14 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
   <body>
-    <%= yield %>
+    <header>
+    </header>
+    <main>
+      <div class="base-container <%= max_width %>">
+        <%= yield %>
+      </div>
+    </main>
+    <footer>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
close #3

## 実装内容

- `application.html.erb`の`body`の部分を変更

- `全体`と`max-width`のCSSを設定

- 全体の横幅を設定する`max_width`メソッドを追加

- **`Devise 導入後`にコメ ントアウトを解除してください。**
    `app/helpers/application_helper.rb`

<br>

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

