### PR TITLE
表示名の設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "2.7.3"
 
 gem "bootsnap", ">= 1.4.4", require: false
 gem "devise"
+gem "enum_help"
 gem "jbuilder", "~> 2.7"
 gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.15.0)
     globalid (0.4.2)
@@ -238,6 +240,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   devise
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,0 +1,13 @@
+ja:
+  enums:
+    text:
+      genre: &language
+        invisible: '非表示'
+        basic: 'Basic'
+        git: 'Git'
+        ruby: 'Ruby'
+        rails: 'Ruby on Rails'
+        php: 'PHP'
+
+    movie:
+      genre: *language

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_18_052724) do
+ActiveRecord::Schema.define(version: 2021_05_19_062823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.datetime "remember_created_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
 
   create_table "movies", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
@@ -37,7 +29,15 @@ ActiveRecord::Schema.define(version: 2021_05_18_052724) do
     t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
 
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.datetime "remember_created_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end


### PR DESCRIPTION
close #10 

## 実装内容

- `enum-help `を追加

- `texts`, `movies` テーブルの `genre` に対応する表示名 `config/locales/enums.ja.yml` に追加


## 参考資料

- [【やんばるエキスパート教材】列挙型（enum）とセレクトボックス](https://www.yanbaru-code.com/texts/351)
- [ YAMLのエイリアスとアンカーで設定ファイルをDRYに書ける](https://fuqda.hatenablog.com/entry/2019/03/10/220629)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 備考
#7 `日本語化`が実装次第、動作確認必要