### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -2,11 +2,7 @@ class MoviesController < ApplicationController
   PER_PAGE = 12
 
   def index
-    @movies = if params[:genre] == "php"
-                Movie.includes(:watch_progresses).where(genre: Movie::PHP_GENRE_LIST).page(params[:page]).per(PER_PAGE)
-              else
-                Movie.includes(:watch_progresses).where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
-              end
+    @movies = Movie.includes(:watch_progresses).genre_list(params[:genre]).page(params[:page]).per(PER_PAGE)
   end
 
   def show; end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -2,7 +2,11 @@ class MoviesController < ApplicationController
   PER_PAGE = 12
 
   def index
-    @movies = Movie.includes(:watch_progresses).where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
+    @movies = if params[:genre] == "php"
+                Movie.includes(:watch_progresses).where(genre: Movie::PHP_GENRE_LIST).page(params[:page]).per(PER_PAGE)
+              else
+                Movie.includes(:watch_progresses).where(genre: Movie::RAILS_GENRE_LIST).page(params[:page]).per(PER_PAGE)
+              end
   end
 
   def show; end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def movie_page_title
+    if params[:genre] == "php"
+      "PHP 動画"
+    else
+      "Ruby/Rails 動画"
+    end
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -21,4 +21,5 @@ class Movie < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP_GENRE_LIST = %w[php].freeze
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -22,4 +22,12 @@ class Movie < ApplicationRecord
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
   PHP_GENRE_LIST = %w[php].freeze
+
+  def self.genre_list(genre)
+    if genre == "php"
+      Movie.where(genre: Movie::PHP_GENRE_LIST)
+    else
+      Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    end
+  end
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
-  <h1 class="text-center mt-2 mb-4">Ruby/Rails <br class="d-sm-none">
-    動画</h1>
+  <h1 class="text-center mt-2 mb-4"> <%= movie_page_title %> <br class="d-sm-none">
+  </h1>
   <div class="row row-eq-height">
     <%= render partial: "movie", collection: @movies %>
   </div>


### PR DESCRIPTION
(参考: https://docs.github.com/ja/github/collaborating-with-issues-and-pull-requests/closing-a-pull-request )

close #18 

## 実装内容

- php動画教材ページのリンクをクリックするとphp動画のみが表示される様にした
  - モデルのインスタンスメソッドに、教材動画の表示条件式を記載
  - ヘルパーに、ページタイトルの表示条件式を記載

## 参考資料
- Active Recordの様々なメソッド
  - [やんばるエキスパートアプリ](https://www.yanbaru-code.com/texts/212)

## チェックリスト



- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要があれば）


## 備考（必要があれば）
