### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.genre_list(params[:genre])
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,14 @@ module ApplicationHelper
     end
   end
 
+  def text_page_title
+    if params[:genre] == "php"
+      "PHP テキスト教材"
+    else
+      "Ruby/Rails テキスト教材"
+    end
+  end
+
   def movie_page_title
     if params[:genre] == "php"
       "PHP 動画"

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -20,4 +20,14 @@ class Text < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
+  PHP_GENRE_LIST = %w[php].freeze
+
+  def self.genre_list(genre)
+    if genre == "php"
+      Text.where(genre: Text::PHP_GENRE_LIST)
+    else
+      Text.where(genre: Text::RAILS_GENRE_LIST)
+    end
+  end
 end

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,10 +1,7 @@
 <div class="container">
-  <h1 class="text-center mt-2 mb-4">Ruby/Rails <br class="d-sm-none">
-    テキスト教材</h1>
+  <h1 class="text-center mt-2 mb-4"><%= text_page_title %><br class="d-sm-none">
+  </h1>
   <div class="row">
     <%= render partial: "text", collection: @texts %>
   </div>
 </div>
-
-
-


### PR DESCRIPTION
close #21

## 実装内容

- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正

- 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

